### PR TITLE
Fix message list formatting for cases when a message is an object

### DIFF
--- a/bytestring_splitter/__init__.py
+++ b/bytestring_splitter/__init__.py
@@ -320,7 +320,11 @@ class BytestringSplitter:
         return new_splitter
 
     def nice_message_types(self):
-        return str().join("{}:{}, ".format(t[1].__name__, t[2]) for t in self.message_types)[:-2]
+        display_message_type = lambda t: t.__name__ if isinstance(t, type) else str(t)
+        return str().join("{}:{}, ".format(display_message_type(t[1]), t[2]) for t in self.message_types)[:-2]
+
+    def __str__(self):
+        return "{}({})".format(self.__class__.__name__, self.nice_message_types())
 
     def repeat(self, splittable, as_set=False):
         """

--- a/tests/test_splitters.py
+++ b/tests/test_splitters.py
@@ -222,3 +222,17 @@ def test_bundle_and_dispense_variable_length():
     vbytes = bytes(VariableLengthBytestring.bundle(items))
     items_again = VariableLengthBytestring.dispense(vbytes)
     assert items == items_again
+
+
+def test_deserialization_error_message():
+    # A regression test for a bug when a splitter with a nested splitter could not be formatted
+    # on a deserialization error, and raised a misleading error.
+
+    inner_splitter = BytestringSplitter((bytes, 4))
+    splitter = BytestringSplitter(inner_splitter, (bytes, 1))
+
+    x, y = splitter(b'12345')
+    assert x == b'1234' and y == b'5'
+
+    with pytest.raises(BytestringSplittingError):
+        splitter(b'1234')


### PR DESCRIPTION
Hit this bug in https://github.com/nucypher/nucypher/pull/2730. Without the change the error in the new test looks like

```
>       splitter(b'1234')

tests/test_splitters.py:234: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
bytestring_splitter/__init__.py:159: in __call__
    raise BytestringSplittingError(message.format(self.nice_message_types(), len(self), len(splittable)))
bytestring_splitter/__init__.py:323: in nice_message_types
    return str().join("{}:{}, ".format(t[1].__name__, t[2]) for t in self.message_types)[:-2]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

.0 = <list_iterator object at 0x1147a2050>

>   return str().join("{}:{}, ".format(t[1].__name__, t[2]) for t in self.message_types)[:-2]
E   AttributeError: 'BytestringSplitter' object has no attribute '__name__'
```

Not sure what's the best way to format a `BytestringSplitter` object - I just added a `__str__` implementation based on `nice_message_types()`. If I understand correctly, `t[1]` can be either a type, or a `BytestringSplitter`/`BytestringKwargifier` object.


